### PR TITLE
Now enforcing Vagrant 1.9.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.2 (TBD)
+
+FEATURES:
+
+
+IMPROVEMENTS:
+
+  - Now enforcing Vagrant >=1.9.7
+
+BUG FIXES:
+
+
 ## 0.2.1 (August 9, 2017)
 
 FEATURES:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ require 'getoptlong'
 
 load "vagrant_resources/modules.rb" # for random_tag
 
+Vagrant.require_version ">= 1.9.7"
+
 opts = GetoptLong.new(
   # Native Vagrant options
   [ '--force', '-f', GetoptLong::NO_ARGUMENT ],

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -18,6 +18,15 @@ You need to install some programs into your host, then you will need to install 
 [OSX](http://www.apple.com/mac-mini/)
 
 ## Dependencies:
+
+Download and install your Vagrant and VirtualBox.
+
+- [Vagrant](http://www.vagrantup.com/)
+
+- [VirtualBox 5.1 or newer](https://www.virtualbox.org/)
+
+Note: Vagrant and VirtualBox update frequently, and sometimes with breaking changes. Additionally there are host OS specific dependencies below.
+
 ### Dependencies (Ubuntu):
 You first need to install some dependencies for your host OS. For Ubuntu based systems, run:
 
@@ -26,22 +35,9 @@ You first need to install some dependencies for your host OS. For Ubuntu based s
 sudo apt install -y build-essential linux-headers-$(uname -r) lxc lxc-templates cgroup-lite redir xclip
 ```
 
-Then install your correct Deb packages:
-
-[Vagrant 1.9.7 or newer](http://www.vagrantup.com/)
-
-[VirtualBox 5.1 or newer](https://www.virtualbox.org/)
-
-Note: Vagrant and VirtualBox update frequently, and sometimes with breaking changes.
-
 ### Dependencies (Mac):
-For OS X installing 2 dmg files should be all you need
 
-[Vagrant 1.9.7 or newer](http://www.vagrantup.com/)
-
-[VirtualBox 5.1 or newer](https://www.virtualbox.org/)
-
-Note: Vagrant and VirtualBox update frequently, and sometimes with breaking changes.
+There are no additional dependencies for Mac, however, LXC cannot be used as a provider at this time.
 
 #### Install Vagrant plugins:
 cd into the `rambo` repo and run:


### PR DESCRIPTION
Fixes #43 

When the requirement isn't met, the error is all in red and looks like this:
```
$ vagrant destroy
This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

  >= 1.9.7

You are running Vagrant 1.9.5, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.
```