### PR TITLE
Vagrant env vars now able to be set via cli

### DIFF
--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -59,7 +59,8 @@ pass_context = click.make_pass_decorator(Context, ensure=True)
               help='Debug option not yet implemented.')
 @click.option('--vagrant-cwd', default=None, type=click.Path(),
               help='Path entry point to the Vagrantfile. Defaults to '
-              'the Vagrantfile where %s is installed' % PROJECT_NAME)
+              'the Vagrantfile provided by %s in the installed path.'
+              % PROJECT_NAME.capitalize())
 @click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
               help='Path location of the .vagrant directory for the '
               'virtual machine. Defaults to the current working directory.')
@@ -70,9 +71,9 @@ def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
 
     # Overwrite Vagrant env vars if passed through cli.
     if vagrant_cwd:
-        os.environ['VAGRANT_CWD'] = vagrant_cwd
+        os.environ['VAGRANT_CWD'] = os.path.normpath(vagrant_cwd)
     if vagrant_dotfile_path:
-        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.join(vagrant_dotfile_path + '/.vagrant')
+        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(vagrant_dotfile_path + '/.vagrant'))
 
 context_settings = {'ignore_unknown_options':True, 'allow_extra_args':True}
 @cli.command(name=cmd, context_settings=context_settings)

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -69,7 +69,7 @@ def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
     if debug:
         ctx._debug = debug
 
-    # Overwrite Vagrant env vars if passed through cli.
+    # Overwrite Vagrant env vars if cli option is passed.
     if vagrant_cwd:
         os.environ['VAGRANT_CWD'] = os.path.normpath(vagrant_cwd)
     if vagrant_dotfile_path:

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -26,8 +26,7 @@ if len(sys.argv) > 1:
 
 
 def set_env_var(name, value):
-    '''
-    Set an environment variable in all caps that is prefixed with the name of the project
+    '''Set an environment variable in all caps that is prefixed with the name of the project
     '''
     os.environ[PROJECT_NAME.upper() + "_" + name.upper()] = value
 
@@ -38,29 +37,42 @@ class Context(object):
         self._tmp_path = os.path.join(os.getcwd(), '.tmp')
         self._provider = None
         self._debug = False
-        self._vagrant = True
 
         # env vars used by Python and Ruby
         set_env_var('env', self._project_path)
         set_env_var('tmp', self._tmp_path)
 
-        if self._vagrant:
-            # Vagrant requires the following 2 env vars for custom cwd and dotfile path.
-            if 'VAGRANT_CWD' not in os.environ: # Where the Vagrantfile and python code are
-                os.environ['VAGRANT_CWD'] = self._project_path # (default installed path)
-            if 'VAGRANT_DOTFILE_PATH' not in os.environ: # Where to put .vagrant dir (right next to .tmp)
-                os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
+        ## Vagrant requires the following env vars for custom cwd and dotfile path. Keep if already set.
+        # Where the Vagrantfile is located
+        if 'VAGRANT_CWD' not in os.environ:
+            os.environ['VAGRANT_CWD'] = self._project_path # (default installed path)
+        # Where to put .vagrant dir and .tmp dirs
+        if 'VAGRANT_DOTFILE_PATH' not in os.environ:
+            os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
 
 
 pass_context = click.make_pass_decorator(Context, ensure=True)
 
 
 @click.group()
-@click.option('--debug/--no-debug', default=False)
+@click.option('--debug/--no-debug', default=False,
+              help='Debug option not yet implemented.')
+@click.option('--vagrant-cwd', default=None, type=click.Path(),
+              help='Path entry point to the Vagrantfile. Defaults to '
+              'the Vagrantfile where %s is installed' % PROJECT_NAME)
+@click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
+              help='Path location of the .vagrant directory for the '
+              'virtual machine. Defaults to the current working directory.')
 @pass_context
-def cli(ctx, debug):
+def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
     if debug:
         ctx._debug = debug
+
+    # Overwrite Vagrant env vars if passed through cli.
+    if vagrant_cwd:
+        os.environ['VAGRANT_CWD'] = vagrant_cwd
+    if vagrant_dotfile_path:
+        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.join(vagrant_dotfile_path + '/.vagrant')
 
 context_settings = {'ignore_unknown_options':True, 'allow_extra_args':True}
 @cli.command(name=cmd, context_settings=context_settings)
@@ -79,8 +91,7 @@ def gen():
               help='Provider for the virtual machine. '
               'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
 def up(provider):
-    '''
-    Call Vagrant up with provider option. Provider may also be supplied by
+    '''Call Vagrant up with provider option. Provider may also be supplied by
     the RAMBO_PROVIDER environment variable if not passed as a cli option.
     '''
     # Abort if provider not in whitelist.
@@ -94,14 +105,20 @@ def up(provider):
 
 @cli.command()
 def ssh():
+    '''Connect to an running virtual machine over ssh.
+    '''
     vagrant_ssh()
 
 @cli.command()
 def destroy():
+    '''Destroy a virtual machine and all its metadata. Default leaves logs.
+    '''
     vagrant_destroy()
 
 @cli.command()
 def setup(): # threaded setup commands
+    '''Runs any setup commands. None yet implemented.
+    '''
     # setup_rambo()
     setup_lastpass()
 


### PR DESCRIPTION
Ref #106 

Using these two new cli options you can set both the location of the .vagrant dir and the Vagrantfile. If used for `up` these options are required for `ssh` and `destroy` later on, or else Rambo won't know how to find the VM that's being used, i.e., Rambo will look in the default locations, which may not be desired. E.g. do `rambo --vagrant-dotfile-path ~/my/dir up` and `rambo --vagrant-dotfile-path ~/my/dir ssh`

`--vagrant-dotfile-path` and `--vagrant-cwd` have the highest priority. Environment variables can still be used if set, if no cli option is passed. If no option or env vars are set, the defaults are still calculated.