### PR TITLE
Added a Python API and allowed setting Vagrant path options

### DIFF
--- a/rambo/app.py
+++ b/rambo/app.py
@@ -19,7 +19,6 @@ with open(os.path.join(PROJECT_LOCATION, 'settings.json'), 'r') as f:
 PROVIDERS = SETTINGS['PROVIDERS']
 PROJECT_NAME = SETTINGS['PROJECT_NAME']
 
-# Progressively read a file as it's being written to by another function, i.e. Vagrant.
 # XXX: We should refactor this to catch output directly from Vagrant, and pass it to
 # the shell and a copy to log file. Doing logic on the contents of a log file isn't going to be
 # stable. For instance, we shouldn't have to specify any exit_triggers. We can't factor in every
@@ -50,7 +49,7 @@ def set_init_vars():
     '''Set custom environment variables that are always going to be needed by
     our custom Ruby code in the Vagrantfile chain.
     '''
-    # env vars used by Python and Ruby
+    # env vars available to Python and Ruby
     set_env_var('ENV', PROJECT_LOCATION) # location of this code
     set_env_var('TMP', os.path.join(os.getcwd(), '.tmp')) # tmp in cwd
 

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -86,7 +86,7 @@ def vagrant_up(ctx=None, provider=None, vagrant_cwd=None, vagrant_dotfile_path=N
     All str args can also be set as an environment variable; arg takes precedence.
 
     Agrs:
-        ctx (object): Click Context object.
+        ctx (object): Click Context object. Used to detect if CLI is used.
         provider (str): Sets provider used.
         vagrant_cwd (str): Location of `Vagrantfile`.
         vagrant_dotfile_path (str): Location of `.vagrant` metadata directory.

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -1,11 +1,9 @@
 import os
 import sys
 import json
-import ipdb
 import click
 from bash import bash
 
-from rambo.utils import set_env_var
 from rambo.app import vagrant_up, vagrant_ssh, vagrant_destroy, set_init_vars, set_vagrant_vars
 
 ## GLOBALS

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -6,7 +6,7 @@ import click
 from bash import bash
 
 from rambo.utils import set_env_var
-from rambo.app import vagrant_up, vagrant_ssh, vagrant_destroy
+from rambo.app import vagrant_up, vagrant_ssh, vagrant_destroy, set_init_vars, set_vagrant_vars
 
 ## GLOBALS
 # Create env var indicating where this code lives. This will be used latter by
@@ -25,34 +25,7 @@ if len(sys.argv) > 1:
     if cmd in command_handeled_by_click:
         cmd = ''
 
-class Context(object):
-    def __init__(self):
-        self.project_path = PROJECT_LOCATION
-        self._tmp_path = os.path.join(os.getcwd(), '.tmp')
-        self._provider = None
-        self.debug = False
-        self.vagrant_cwd = None
-        self.vagrant_dotfile_path = None
-
-        # env vars used by Python and Ruby
-        set_env_var('env', self.project_path)
-        set_env_var('tmp', self._tmp_path)
-
-        ## Vagrant requires the following env vars for custom cwd and dotfile path. Keep if already set.
-        # Where the Vagrantfile is located
-        if 'VAGRANT_CWD' not in os.environ:
-            os.environ['VAGRANT_CWD'] = self.project_path # (default installed path)
-        # Where to put .vagrant dir and .tmp dirs
-        if 'VAGRANT_DOTFILE_PATH' not in os.environ:
-            os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
-
-
-pass_context = click.make_pass_decorator(Context, ensure=True)
-
-
 @click.group()
-@click.option('--debug/--no-debug', default=False,
-              help='Debug option not yet implemented.')
 @click.option('--vagrant-cwd', default=None, type=click.Path(),
               help='Path entry point to the Vagrantfile. Defaults to '
               'the Vagrantfile provided by %s in the installed path.'
@@ -60,17 +33,10 @@ pass_context = click.make_pass_decorator(Context, ensure=True)
 @click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
               help='Path location of the .vagrant directory for the '
               'virtual machine. Defaults to the current working directory.')
-@pass_context
-def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
-    if debug:
-        ctx.debug = debug
-
-    # Overwrite Vagrant env vars if cli option is passed.
-    if vagrant_cwd:
-        os.environ['VAGRANT_CWD'] = os.path.normpath(vagrant_cwd) #os.environ['VAGRANT_CWD'] = 
-    if vagrant_dotfile_path:
-        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(vagrant_dotfile_path + '/.vagrant'))
-#    ipdb.set_trace()
+@click.pass_context
+def cli(ctx, vagrant_cwd, vagrant_dotfile_path):
+    set_init_vars()
+    set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
 context_settings = {'ignore_unknown_options':True, 'allow_extra_args':True}
 @cli.command(name=cmd, context_settings=context_settings)
@@ -88,22 +54,23 @@ def gen():
 @click.option('-p', '--provider', envvar = PROJECT_NAME.upper() + '_PROVIDER',
               help='Provider for the virtual machine. '
               'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
-@pass_context
+@click.pass_context
 def up(ctx, provider):
     '''Call Vagrant up with provider option. Provider may also be supplied by
     the RAMBO_PROVIDER environment variable if not passed as a cli option.
     '''
-    ipdb.set_trace()
     vagrant_up(ctx, provider)
 
 @cli.command()
-def ssh():
+@click.pass_context
+def ssh(ctx):
     '''Connect to an running virtual machine over ssh.
     '''
     vagrant_ssh()
 
 @cli.command()
-def destroy():
+@click.pass_context
+def destroy(ctx):
     '''Destroy a virtual machine and all its metadata. Default leaves logs.
     '''
     vagrant_destroy()

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -59,7 +59,8 @@ pass_context = click.make_pass_decorator(Context, ensure=True)
               help='Debug option not yet implemented.')
 @click.option('--vagrant-cwd', default=None, type=click.Path(),
               help='Path entry point to the Vagrantfile. Defaults to '
-              'the Vagrantfile where %s is installed' % PROJECT_NAME)
+              'the Vagrantfile provided by %s in the installed path.'
+              % PROJECT_NAME.capitalize())
 @click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
               help='Path location of the .vagrant directory for the '
               'virtual machine. Defaults to the current working directory.')
@@ -70,9 +71,9 @@ def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
 
     # Overwrite Vagrant env vars if passed through cli.
     if vagrant_cwd:
-        os.environ['VAGRANT_CWD'] = vagrant_cwd
+        os.environ['VAGRANT_CWD'] = os.path.normpath(vagrant_cwd)
     if vagrant_dotfile_path:
-        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.join(vagrant_dotfile_path + '/.vagrant')
+        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(vagrant_dotfile_path + '/.vagrant'))
 
 context_settings = {'ignore_unknown_options':True, 'allow_extra_args':True}
 @cli.command(name=cmd, context_settings=context_settings)

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -69,7 +69,7 @@ def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
     if debug:
         ctx._debug = debug
 
-    # Overwrite Vagrant env vars if passed through cli.
+    # Overwrite Vagrant env vars if cli option is passed.
     if vagrant_cwd:
         os.environ['VAGRANT_CWD'] = os.path.normpath(vagrant_cwd)
     if vagrant_dotfile_path:

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -26,8 +26,7 @@ if len(sys.argv) > 1:
 
 
 def set_env_var(name, value):
-    '''
-    Set an environment variable in all caps that is prefixed with the name of the project
+    '''Set an environment variable in all caps that is prefixed with the name of the project
     '''
     os.environ[PROJECT_NAME.upper() + "_" + name.upper()] = value
 
@@ -38,29 +37,42 @@ class Context(object):
         self._tmp_path = os.path.join(os.getcwd(), '.tmp')
         self._provider = None
         self._debug = False
-        self._vagrant = True
 
         # env vars used by Python and Ruby
         set_env_var('env', self._project_path)
         set_env_var('tmp', self._tmp_path)
 
-        if self._vagrant:
-            # Vagrant requires the following 2 env vars for custom cwd and dotfile path.
-            if 'VAGRANT_CWD' not in os.environ: # Where the Vagrantfile and python code are
-                os.environ['VAGRANT_CWD'] = self._project_path # (default installed path)
-            if 'VAGRANT_DOTFILE_PATH' not in os.environ: # Where to put .vagrant dir (right next to .tmp)
-                os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
+        ## Vagrant requires the following env vars for custom cwd and dotfile path. Keep if already set.
+        # Where the Vagrantfile is located
+        if 'VAGRANT_CWD' not in os.environ:
+            os.environ['VAGRANT_CWD'] = self._project_path # (default installed path)
+        # Where to put .vagrant dir and .tmp dirs
+        if 'VAGRANT_DOTFILE_PATH' not in os.environ:
+            os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
 
 
 pass_context = click.make_pass_decorator(Context, ensure=True)
 
 
 @click.group()
-@click.option('--debug/--no-debug', default=False)
+@click.option('--debug/--no-debug', default=False,
+              help='Debug option not yet implemented.')
+@click.option('--vagrant-cwd', default=None, type=click.Path(),
+              help='Path entry point to the Vagrantfile. Defaults to '
+              'the Vagrantfile where %s is installed' % PROJECT_NAME)
+@click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
+              help='Path location of the .vagrant directory for the '
+              'virtual machine. Defaults to the current working directory.')
 @pass_context
-def cli(ctx, debug):
+def cli(ctx, debug, vagrant_cwd, vagrant_dotfile_path):
     if debug:
         ctx._debug = debug
+
+    # Overwrite Vagrant env vars if passed through cli.
+    if vagrant_cwd:
+        os.environ['VAGRANT_CWD'] = vagrant_cwd
+    if vagrant_dotfile_path:
+        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.join(vagrant_dotfile_path + '/.vagrant')
 
 context_settings = {'ignore_unknown_options':True, 'allow_extra_args':True}
 @cli.command(name=cmd, context_settings=context_settings)
@@ -79,8 +91,7 @@ def gen():
               help='Provider for the virtual machine. '
               'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
 def up(provider):
-    '''
-    Call Vagrant up with provider option. Provider may also be supplied by
+    '''Call Vagrant up with provider option. Provider may also be supplied by
     the RAMBO_PROVIDER environment variable if not passed as a cli option.
     '''
     # Abort if provider not in whitelist.
@@ -94,14 +105,20 @@ def up(provider):
 
 @cli.command()
 def ssh():
+    '''Connect to an running virtual machine over ssh.
+    '''
     vagrant_ssh()
 
 @cli.command()
 def destroy():
+    '''Destroy a virtual machine and all its metadata. Default leaves logs.
+    '''
     vagrant_destroy()
 
 @cli.command()
 def setup(): # threaded setup commands
+    '''Runs any setup commands. None yet implemented.
+    '''
     # setup_rambo()
     setup_lastpass()
 

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -54,22 +54,21 @@ def gen():
               'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
 @click.pass_context
 def up(ctx, provider):
-    '''Call Vagrant up with provider option. Provider may also be supplied by
-    the RAMBO_PROVIDER environment variable if not passed as a cli option.
+    '''Start a VM / container with `vagrant up`.
     '''
     vagrant_up(ctx, provider)
 
 @cli.command()
 @click.pass_context
 def ssh(ctx):
-    '''Connect to an running virtual machine over ssh.
+    '''Connect to an running VM / container over ssh.
     '''
     vagrant_ssh()
 
 @cli.command()
 @click.pass_context
 def destroy(ctx):
-    '''Destroy a virtual machine and all its metadata. Default leaves logs.
+    '''Destroy a VM / container and all its metadata. Default leaves logs.
     '''
     vagrant_destroy()
 

--- a/rambo/utils.py
+++ b/rambo/utils.py
@@ -23,11 +23,6 @@ def get_env_var(name):
     '''
     return os.environ.get(PROJECT_NAME.upper() + "_" + name.upper())
 
-def set_vagrant_env_var(name, value):
-    '''Set an environment variable in all caps that is prefixed with the name of the project
-    '''
-    os.environ["VAGRANT_" + name.upper()] = value
-
 def dir_exists(path):
     return os.path.isdir(path)
 

--- a/rambo/utils.py
+++ b/rambo/utils.py
@@ -1,7 +1,27 @@
 import os
+import json
 
 from pathlib import Path
 from shutil import copyfile, move, rmtree
+
+## GLOBALS
+# Create env var indicating where this code lives. This will be used latter by
+# Vagrant as a check that the python cli is being used, as well as being a useful var.
+PROJECT_LOCATION = os.path.dirname(os.path.realpath(__file__))
+with open(os.path.join(PROJECT_LOCATION, 'settings.json'), 'r') as f:
+    SETTINGS = json.load(f)
+PROVIDERS = SETTINGS['PROVIDERS']
+PROJECT_NAME = SETTINGS['PROJECT_NAME']
+
+def set_env_var(name, value):
+    '''Set an environment variable in all caps that is prefixed with the name of the project
+    '''
+    os.environ[PROJECT_NAME.upper() + "_" + name.upper()] = value
+
+def set_vagrant_env_var(name, value):
+    '''Set an environment variable in all caps that is prefixed with the name of the project
+    '''
+    os.environ["VAGRANT_" + name.upper()] = value
 
 def dir_exists(path):
     return os.path.isdir(path)

--- a/rambo/utils.py
+++ b/rambo/utils.py
@@ -18,6 +18,11 @@ def set_env_var(name, value):
     '''
     os.environ[PROJECT_NAME.upper() + "_" + name.upper()] = value
 
+def get_env_var(name):
+    '''Set an environment variable in all caps that is prefixed with the name of the project
+    '''
+    return os.environ.get(PROJECT_NAME.upper() + "_" + name.upper())
+
 def set_vagrant_env_var(name, value):
     '''Set an environment variable in all caps that is prefixed with the name of the project
     '''
@@ -31,7 +36,10 @@ def dir_create(path):
         os.makedirs(path)
 
 def dir_delete(path):
-    rmtree(path)
+    try:
+        rmtree(path)
+    except FileNotFoundError:
+        pass
 
 def file_delete(path):
     try:


### PR DESCRIPTION
Ref #106 and #108

This adds a Python API, so that you can run `vagrant_up`, `vagrant_ssh`, and `vagrant_destroy` from the CLI or from Python after importing rambo. Both ways also support each option. This change involved abstracting some logic out of cli.py and into app.py, so it can be used in either circumstance. 

`VAGRANT_DOTFILE_PATH` and `VAGRANT_CWD` options are new in this pull request.