### PR TITLE
[rambo-119] Fixing bug when salt provisioning is turned off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 FEATURES:
 
+  - Now AWS makes use of VM_Size flag to produce t2.nano, t2.micro, and t2.small VMs.
+
 IMPROVEMENTS:
 
 BUG FIXES:
 
   - Fix Docker failing on editing non-existant bashrc. Now ensuring existence first.
   - Fixing vagrant up exit trigger when VM not named 'default'.
-  - Now AWS makes use of VM_Size flag to produce t2.nano, t2.micro, and t2.small VMs.
+  - Fixed bug preventing provisioning without Salt.
 
 ## 0.3.0 (October 26, 2017)
 

--- a/rambo/Vagrantfile
+++ b/rambo/Vagrantfile
@@ -31,7 +31,7 @@ for link in orphan_links
   puts "Deleting broken symlink #{link}"
   File.delete(link)
 end
-
+-
 VM_NAME = PROJECT_NAME + "-" + random_tag()
 
 FORWARD_SSH = true
@@ -40,18 +40,24 @@ COPY_DIR_WITH_RSYNC = true
 
 PROVISION_WITH_SALT = true
 
-PROVISION_WITH_CMD = true
+PROVISION_WITH_CMD = false
 
-## Construct commands to have Salt provision the machine.# Pass var to allow Salt to set the hostname to the VM_NAME.
-SET_HOSTNAME = "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local grains.setval hostname " + VM_NAME + " --log-level info; "
+if PROVISION_WITH_SALT
+  ## Construct commands to have Salt provision the machine.
+  # Pass var to allow Salt to set the hostname to the VM_NAME.
+  SET_HOSTNAME = "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local grains.setval hostname " + VM_NAME + " --log-level info; "
 
-# Set hostname + run highstate.
-PROVISION_CMD = SET_HOSTNAME + "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local state.highstate --log-level info"
+  # Set hostname + run highstate.
+  PROVISION_SALT_CMD = SET_HOSTNAME + "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local state.highstate --log-level info"
 
-# Add website branch var if applicable.
-if ENV["WEBSITE_BRANCH"]
-  PROVISION_CMD = "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local grains.setval WEBSITE_BRANCH " + ENV["WEBSITE_BRANCH"] + " --log-level info; " + PROVISION_CMD
+  # Add website branch var if applicable.
+  if ENV["WEBSITE_BRANCH"]
+    PROVISION_SALT_CMD = "sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK salt-call --local grains.setval WEBSITE_BRANCH " + ENV["WEBSITE_BRANCH"] + " --log-level info; " + PROVISION_SALT_CMD
+  end
 end
 
+if PROVISION_WITH_CMD
+  PROVISION_CMD = ""
+end
 #load the rest of the vagrant ruby code
 load File.expand_path("vagrant_resources/vagrant/core")

--- a/rambo/vagrant_resources/vagrant/Vagrantfile.digitalocean
+++ b/rambo/vagrant_resources/vagrant/Vagrantfile.digitalocean
@@ -51,9 +51,11 @@ Vagrant.configure("2") do |config|
       mkdir -p /vagrant/salt_resources/states/files/licenses
       if [ -d "/vagrant/auth/licenses/" ]; then cp -a /vagrant/auth/licenses/. /vagrant/salt_resources/states/files/licenses/; fi
     EOS
-
     config.vm.provision "shell",
       inline: $pre_salt,
+      keep_color: true
+    config.vm.provision "shell",
+      inline: PROVISION_SALT_CMD,
       keep_color: true
   end
   if PROVISION_WITH_CMD

--- a/rambo/vagrant_resources/vagrant/Vagrantfile.docker
+++ b/rambo/vagrant_resources/vagrant/Vagrantfile.docker
@@ -44,9 +44,11 @@ Vagrant.configure("2") do |config|
       mkdir -p /vagrant/salt_resources/states/files/licenses
       if [ -d "/vagrant/auth/licenses/" ]; then cp -a /vagrant/auth/licenses/. /vagrant/salt_resources/states/files/licenses/; fi
     EOS
-
     config.vm.provision "shell",
       inline: $pre_salt,
+      keep_color: true
+    config.vm.provision "shell",
+      inline: PROVISION_SALT_CMD,
       keep_color: true
   end
   if PROVISION_WITH_CMD

--- a/rambo/vagrant_resources/vagrant/Vagrantfile.ec2
+++ b/rambo/vagrant_resources/vagrant/Vagrantfile.ec2
@@ -59,9 +59,11 @@ Vagrant.configure("2") do |config|
       mkdir -p /vagrant/salt_resources/states/files/licenses
       if [ -d "/vagrant/auth/licenses/" ]; then cp -a /vagrant/auth/licenses/. /vagrant/salt_resources/states/files/licenses/; fi
     EOS
-
     config.vm.provision "shell",
       inline: $pre_salt,
+      keep_color: true
+    config.vm.provision "shell",
+      inline: PROVISION_SALT_CMD,
       keep_color: true
   end
   if PROVISION_WITH_CMD

--- a/rambo/vagrant_resources/vagrant/Vagrantfile.lxc
+++ b/rambo/vagrant_resources/vagrant/Vagrantfile.lxc
@@ -59,9 +59,11 @@ Vagrant.configure("2") do |config|
       mkdir -p /vagrant/salt_resources/states/files/licenses
       if [ -d "/vagrant/auth/licenses/" ]; then cp -a /vagrant/auth/licenses/. /vagrant/salt_resources/states/files/licenses/; fi
     EOS
-
     config.vm.provision "shell",
       inline: $pre_salt,
+      keep_color: true
+    config.vm.provision "shell",
+      inline: PROVISION_SALT_CMD,
       keep_color: true
   end
   if PROVISION_WITH_CMD

--- a/rambo/vagrant_resources/vagrant/Vagrantfile.virtualbox
+++ b/rambo/vagrant_resources/vagrant/Vagrantfile.virtualbox
@@ -132,6 +132,9 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell",
       inline: $pre_salt,
       keep_color: true
+    config.vm.provision "shell",
+      inline: PROVISION_SALT_CMD,
+      keep_color: true
   end
   if PROVISION_WITH_CMD
     config.vm.provision "shell",


### PR DESCRIPTION
Ref #119 

Now there is a separate shell command for salt and for std bash provisioning. There is no std bash provisioning by default though, so I flagged that with `false`

I really want to also do #126 now. So much duplicated provisioning code.