### PR TITLE
The .rambo-tmp directory's placement PATH can now be manually set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following environment variables are used by Rambo:
 - `VAGRANT_DOTFILE_PATH` - [This is used by Vagrant directly](https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_dotfile_path), and is able to be set via the CLI / API.
 - `VAGRANT_CWD` - [This is used by Vagrant directly](https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_cwd), and is able to be set via the CLI / API.
 - `RAMBO_ENV` - This is the location of the project environment Rambo's code lives in. It is generated internally and not able to be set with the CLI / API.
-- `RAMBO_TMP` - This is the location of Rambo's metadata folder specific to each VM. It is automatically placed in the CWD when the CLI / API is used.
+- `RAMBO_TMPDIR_PATH` - This is the location of Rambo's metadata folder specific to each VM. It is automatically placed in the CWD when the CLI / API is used.
 - `RAMBO_PROVIDER` - This is the provider that is being used. It is able to be set via the CLI / API.
 
 ### SSH Alias: Key Sharing and Emacs

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Currently, all of the CLI options can also be set as environment variables. Envi
 
 ### Environment Variables
 
-The following environment variables are used by Rambo:
+The following environment variables are used by Rambo, and can be set manually before using Rambo to change its behavior:
 
 - `VAGRANT_DOTFILE_PATH` - [This is used by Vagrant directly](https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_dotfile_path), and is able to be set via the CLI / API.
 - `VAGRANT_CWD` - [This is used by Vagrant directly](https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_cwd), and is able to be set via the CLI / API.

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -52,12 +52,13 @@ def set_init_vars(tmpdir_path=None):
     # env vars available to Python and Ruby
     set_env_var('ENV', PROJECT_LOCATION) # location of this code
     
-    if tmpdir_path:
+    # loc of tmpdir_path
+    if tmpdir_path: # cli / api
         set_env_var('TMPDIR_PATH', os.path.join(tmpdir_path + '.' + PROJECT_NAME + '-tmp'))
-    elif get_env_var('TMPDIR_PATH'):
+    elif get_env_var('TMPDIR_PATH'): # Previously set env var
         set_env_var('TMPDIR_PATH', os.path.join(get_env_var('TMPDIR_PATH') + '.' + PROJECT_NAME + '-tmp'))
-    else:
-        set_env_var('TMPDIR_PATH', os.path.join(os.getcwd(), '.' + PROJECT_NAME + '-tmp'))
+    else: # Not set, set to default loc
+        set_env_var('TMPDIR_PATH', os.path.join(os.getcwd(), '.' + PROJECT_NAME + '-tmp')) # default (cwd)
         
 def set_vagrant_vars(vagrant_cwd=None, vagrant_dotfile_path=None):
     '''Set the environment varialbes prefixed with `VAGRANT_` that vagrant
@@ -68,15 +69,16 @@ def set_vagrant_vars(vagrant_cwd=None, vagrant_dotfile_path=None):
         vagrant_dotfile_path (str): Location of `.vagrant` metadata directory.
     '''
 
-    if vagrant_cwd: # loc of Vagrantfile
-        os.environ["VAGRANT_CWD"] = vagrant_cwd # custom
-    elif 'VAGRANT_CWD' not in os.environ:
-        os.environ['VAGRANT_CWD'] = PROJECT_LOCATION # (default installed path)
-
-    if vagrant_dotfile_path: # loc of .vagrant dir
-        os.environ['VAGRANT_DOTFILE_PATH'] = vagrant_dotfile_path # custom
-    elif 'VAGRANT_DOTFILE_PATH' not in os.environ:
-        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # (default cwd)
+    # loc of Vagrantfile
+    if vagrant_cwd: # cli / api
+        os.environ["VAGRANT_CWD"] = vagrant_cwd
+    elif 'VAGRANT_CWD' not in os.environ: # Not set in env var
+        os.environ['VAGRANT_CWD'] = PROJECT_LOCATION # default (installed path)
+    # loc of .vagrant dir
+    if vagrant_dotfile_path: # cli / api
+        os.environ['VAGRANT_DOTFILE_PATH'] = vagrant_dotfile_path
+    elif 'VAGRANT_DOTFILE_PATH' not in os.environ: # Not set in env var
+        os.environ['VAGRANT_DOTFILE_PATH'] = os.path.normpath(os.path.join(os.getcwd() + '/.vagrant')) # default (cwd)
 
 def vagrant_up_thread():
     '''Make the final call over the shell to `vagrant up`, and redirect

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -45,14 +45,20 @@ def follow_log_file(log_file_path, exit_triggers):
             if any(string in line for string in exit_triggers):
                 break
 
-def set_init_vars():
+def set_init_vars(tmpdir_path=None):
     '''Set custom environment variables that are always going to be needed by
     our custom Ruby code in the Vagrantfile chain.
     '''
     # env vars available to Python and Ruby
     set_env_var('ENV', PROJECT_LOCATION) # location of this code
-    set_env_var('TMP', os.path.join(os.getcwd(), '.' + PROJECT_NAME + '-tmp')) # tmp in cwd
-
+    
+    if tmpdir_path:
+        set_env_var('TMPDIR_PATH', os.path.join(tmpdir_path + '.' + PROJECT_NAME + '-tmp'))
+    elif get_env_var('TMPDIR_PATH'):
+        set_env_var('TMPDIR_PATH', os.path.join(get_env_var('TMPDIR_PATH') + '.' + PROJECT_NAME + '-tmp'))
+    else:
+        set_env_var('TMPDIR_PATH', os.path.join(os.getcwd(), '.' + PROJECT_NAME + '-tmp'))
+        
 def set_vagrant_vars(vagrant_cwd=None, vagrant_dotfile_path=None):
     '''Set the environment varialbes prefixed with `VAGRANT_` that vagrant
     expects, and that we use, to modify some use paths.
@@ -77,9 +83,9 @@ def vagrant_up_thread():
     all output to log file.
     '''
 
-    dir_create(get_env_var('TMP') + '/logs')
+    dir_create(get_env_var('TMPDIR_PATH') + '/logs')
     # TODO: Better logs.
-    bash('vagrant up >' + get_env_var('TMP') + '/logs/vagrant-up-log 2>&1')
+    bash('vagrant up >' + get_env_var('TMPDIR_PATH') + '/logs/vagrant-up-log 2>&1')
 
 def vagrant_up(ctx=None, provider=None, vagrant_cwd=None, vagrant_dotfile_path=None):
     '''Start a VM / container with `vagrant up`.
@@ -108,15 +114,15 @@ def vagrant_up(ctx=None, provider=None, vagrant_cwd=None, vagrant_dotfile_path=N
                  ' variable, and is not in the providers list. Did you '
                  'have a typo?' % provider)
 
-    if not dir_exists(get_env_var('TMP')):
-        dir_create(get_env_var('TMP'))
-    dir_create(get_env_var('TMP') + '/logs')
+    if not dir_exists(get_env_var('TMPDIR_PATH')):
+        dir_create(get_env_var('TMPDIR_PATH'))
+    dir_create(get_env_var('TMPDIR_PATH') + '/logs')
     # TODO: Better logs.
-    open(get_env_var('TMP') + '/logs/vagrant-up-log','w').close() # Create log file. Vagrant will write to it, we'll read it.
+    open(get_env_var('TMPDIR_PATH') + '/logs/vagrant-up-log','w').close() # Create log file. Vagrant will write to it, we'll read it.
 
     thread = Thread(target = vagrant_up_thread) # Threaded to write, read, and echo as `up` progresses.
     thread.start()
-    follow_log_file(get_env_var('TMP') + '/logs/vagrant-up-log', ['Total run time:',
+    follow_log_file(get_env_var('TMPDIR_PATH') + '/logs/vagrant-up-log', ['Total run time:',
                                                  'Provisioners marked to run always will still run',
                                                  'Print this help',
                                                  'try again.'])
@@ -155,14 +161,13 @@ def vagrant_destroy(ctx=None, vagrant_cwd=None, vagrant_dotfile_path=None):
         set_init_vars()
         set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
-
-    dir_create(get_env_var('TMP') + '/logs')
+    dir_create(get_env_var('TMPDIR_PATH') + '/logs')
     # TODO: Better logs.
-    bash('vagrant destroy --force >' + get_env_var('TMP') + '/logs/vagrant-destroy-log 2>&1')
-    follow_log_file( get_env_var('TMP') + '/logs/vagrant-destroy-log', ['Vagrant done with destroy.',
+    bash('vagrant destroy --force >' + get_env_var('TMPDIR_PATH') + '/logs/vagrant-destroy-log 2>&1')
+    follow_log_file( get_env_var('TMPDIR_PATH') + '/logs/vagrant-destroy-log', ['Vagrant done with destroy.',
                                                       'Print this help'])
-    file_delete(get_env_var('TMP') + '/provider')
-    file_delete(get_env_var('TMP') + '/random_tag')
+    file_delete(get_env_var('TMPDIR_PATH') + '/provider')
+    file_delete(get_env_var('TMPDIR_PATH') + '/random_tag')
     dir_delete(os.environ.get('VAGRANT_DOTFILE_PATH'))
     click.echo('Temporary files removed')
     click.echo('Destroy complete.')

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -37,9 +37,12 @@ context_settings = {
 @click.option('--vagrant-dotfile-path', default=None, type=click.Path(),
               help='Path location of the .vagrant directory for the '
               'virtual machine. Defaults to the current working directory.')
+@click.option('--tmpdir-path', default=None, type=click.Path(),
+              help='Path location of the .rambo-tmp directory for the virtual'
+              ' machine. Defaults to the current working directory')
 @click.pass_context
-def cli(ctx, vagrant_cwd, vagrant_dotfile_path):
-    set_init_vars()
+def cli(ctx, vagrant_cwd, vagrant_dotfile_path, tmpdir_path):
+    set_init_vars(tmpdir_path)
     set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
 @cli.command(name=cmd, context_settings=context_settings)
@@ -68,14 +71,14 @@ def up(ctx, provider):
 def ssh(ctx):
     '''Connect to an running VM / container over ssh.
     '''
-    vagrant_ssh()
+    vagrant_ssh(ctx)
 
 @cli.command()
 @click.pass_context
 def destroy(ctx):
     '''Destroy a VM / container and all its metadata. Default leaves logs.
     '''
-    vagrant_destroy()
+    vagrant_destroy(ctx)
 
 @cli.command()
 def setup(): # threaded setup commands

--- a/rambo/vagrant_resources/modules.rb
+++ b/rambo/vagrant_resources/modules.rb
@@ -1,6 +1,6 @@
 def random_tag
   host = `hostname`.strip # Get the hostname from the shell and removing trailing \n
-  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMP'] || File.join(Dir.pwd, '.' + PROJECT_NAME + '-tmp')
+  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMPDIR_PATH'] || File.join(Dir.pwd, '.' + PROJECT_NAME + '-tmp')
   Dir.mkdir(tmp_dir) unless Dir.exist?(tmp_dir)
   random_tag_path = File.join(tmp_dir, 'random_tag')
   if File.file?(random_tag_path)
@@ -13,7 +13,7 @@ def random_tag
 end
 
 def read_provider_file
-  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMP'] || File.join(Dir.pwd, '.' + PROJECT_NAME + '-tmp')
+  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMPDIR_PATH'] || File.join(Dir.pwd, '.' + PROJECT_NAME + '-tmp')
   provider_path = File.join(tmp_dir, 'provider')
   if File.file?(provider_path)
     provider=''
@@ -27,7 +27,7 @@ def read_provider_file
 end
 
 def write_provider_file(provider)
-  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMP'] || File.join(Dir.pwd,  '.' + PROJECT_NAME + '-tmp')
+  tmp_dir = ENV[PROJECT_NAME.upcase + '_TMPDIR_PATH'] || File.join(Dir.pwd,  '.' + PROJECT_NAME + '-tmp')
   provider_path = File.join(tmp_dir, 'provider')
   File.write(provider_path, provider)
 end


### PR DESCRIPTION
resolves issue #113

1) Rambo's temporary directory's environment variable name is now: RAMBO_TMPDIR_PATH,
which is now reflected in the documentation.

2) The .rambo-tmp directory can now be manually set through API, CLI, an by setting
the environment variable.

3) a bug in the cli.py file concerning the ctx was fixed for the ssh & destroy
calling functions.

4) An API or CLI set directory path for .rambo-tmp will be used instead of a environment
variable, and the environment variable will be used before assigning the default.