### PR TITLE
Redundant code in virtualboc vagrant file reduced, VM_variables changed and added.

### DIFF
--- a/rambo/Vagrantfile
+++ b/rambo/Vagrantfile
@@ -72,13 +72,13 @@ sizes = {'512' => '20gb',
          '2048' => '40gb',
         }
 
-if not ENV.has_key?("RAMBO_RAM")
-  ENV["RAMBO_RAM"]="2048"
+if not ENV.has_key?(PROJECT_NAME + "_RAM")
+  ENV[PROJECT_NAME + "_RAM"]="2048"
 end
 
-ENV["RAMBO_DRIVESIZE"]=sizes[ENV["RAMBO_RAM"]]
+ENV[PROJECT_NAME + "_DRIVESIZE"]=sizes[ENV[PROJECT_NAME + "_RAM"]]
 
-unless (sizes.include? ENV["RAMBO_RAM"])
+unless (sizes.include? ENV[PROJECT_NAME + "_RAM"])
    abort("ABORTED - VM size not in sizes list. Did you have a typo?")
 end
 

--- a/rambo/Vagrantfile
+++ b/rambo/Vagrantfile
@@ -72,15 +72,13 @@ sizes = {'512' => '20gb',
          '2048' => '40gb',
         }
 
-VM_RAM = if ENV["VMSIZE"] and sizes.has_key? :ENV["VMSIZE"]
-          ENV["VMSIZE"]
-        else
-        '2048'
-         end
+if not ENV.has_key?("RAMBO_RAM")
+  ENV["RAMBO_RAM"]="2048"
+end
 
-VM_HARDDRIVE = sizes[VM_RAM]
+ENV["RAMBO_DRIVESIZE"]=sizes[ENV["RAMBO_RAM"]]
 
-unless (sizes.include? VM_RAM)
+unless (sizes.include? ENV["RAMBO_RAM"])
    abort("ABORTED - VM size not in sizes list. Did you have a typo?")
 end
 

--- a/rambo/Vagrantfile
+++ b/rambo/Vagrantfile
@@ -67,18 +67,20 @@ unless (hosts.include? VM_HOST)
    abort("ABORTED - VM host not in host list. Did you have a typo?")
 end
 
-sizes = ['512mb',
-         '1024mb',
-         '2048mb',
-        ]
+sizes = {'512' => '20gb',
+         '1024' => '30gb',
+         '2048' => '40gb',
+        }
 
-VM_SIZE = if ENV["VMSIZE"]
+VM_RAM = if ENV["VMSIZE"] and sizes.has_key? :ENV["VMSIZE"]
           ENV["VMSIZE"]
         else
-        '2048mb'
-        end
+        '2048'
+         end
 
-unless (sizes.include? VM_SIZE)
+VM_HARDDRIVE = sizes[VM_RAM]
+
+unless (sizes.include? VM_RAM)
    abort("ABORTED - VM size not in sizes list. Did you have a typo?")
 end
 

--- a/rambo/vagrant_resources/vagrantfiles/digitalocean
+++ b/rambo/vagrant_resources/vagrantfiles/digitalocean
@@ -13,11 +13,11 @@ Vagrant.configure("2") do |config|
       provider.image = "ubuntu-16-04-x64"
     end
     provider.region = "nyc1"
-    if VM_SIZE == "512mb"
+    if VM_RAM == "512"
       provider.size = "512mb"
-    elsif VM_SIZE == "1024mb"
+    elsif VM_RAM == "1024"
       provider.size = "1gb"
-    elsif VM_SIZE == "2048mb"
+    elsif VM_RAM == "2048"
       provider.size = "2gb"
     end
   end

--- a/rambo/vagrant_resources/vagrantfiles/digitalocean
+++ b/rambo/vagrant_resources/vagrantfiles/digitalocean
@@ -13,11 +13,11 @@ Vagrant.configure("2") do |config|
       provider.image = "ubuntu-16-04-x64"
     end
     provider.region = "nyc1"
-    if VM_RAM == "512"
+    if ENV"[RAMBO_RAM"] == "512"
       provider.size = "512mb"
-    elsif VM_RAM == "1024"
+    elsif ENV"[RAMBO_RAM"] == "1024"
       provider.size = "1gb"
-    elsif VM_RAM == "2048"
+    elsif ENV"[RAMBO_RAM"] == "2048"
       provider.size = "2gb"
     end
   end

--- a/rambo/vagrant_resources/vagrantfiles/digitalocean
+++ b/rambo/vagrant_resources/vagrantfiles/digitalocean
@@ -13,11 +13,11 @@ Vagrant.configure("2") do |config|
       provider.image = "ubuntu-16-04-x64"
     end
     provider.region = "nyc1"
-    if ENV"[RAMBO_RAM"] == "512"
+    if ENV[PROJECT_NAME + "_RAM"] == "512"
       provider.size = "512mb"
-    elsif ENV"[RAMBO_RAM"] == "1024"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "1024"
       provider.size = "1gb"
-    elsif ENV"[RAMBO_RAM"] == "2048"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "2048"
       provider.size = "2gb"
     end
   end

--- a/rambo/vagrant_resources/vagrantfiles/ec2
+++ b/rambo/vagrant_resources/vagrantfiles/ec2
@@ -15,11 +15,11 @@ Vagrant.configure("2") do |config|
     provider.availability_zone = "us-west-1c"
     provider.region = "us-west-1"
     provider.ami = "ami-a5d621e1"
-    if VM_SIZE == "512mb"
+    if VM_RAM == "512"
       provider.instance_type = "t2.nano"
-    elsif VM_SIZE == "1024mb"
+    elsif VM_RAM == "1024"
       provider.instance_type = "t2.micro"
-    elsif VM_SIZE == "2048mb"
+    elsif VM_RAM == "2048"
       provider.instance_type = "t2.small"
     end
     provider.block_device_mapping = [{

--- a/rambo/vagrant_resources/vagrantfiles/ec2
+++ b/rambo/vagrant_resources/vagrantfiles/ec2
@@ -15,11 +15,11 @@ Vagrant.configure("2") do |config|
     provider.availability_zone = "us-west-1c"
     provider.region = "us-west-1"
     provider.ami = "ami-a5d621e1"
-    if VM_RAM == "512"
+    if ENV"[RAMBO_RAM"] == "512"
       provider.instance_type = "t2.nano"
-    elsif VM_RAM == "1024"
+    elsif ENV"[RAMBO_RAM"] == "1024"
       provider.instance_type = "t2.micro"
-    elsif VM_RAM == "2048"
+    elsif ENV"[RAMBO_RAM"] == "2048"
       provider.instance_type = "t2.small"
     end
     provider.block_device_mapping = [{

--- a/rambo/vagrant_resources/vagrantfiles/ec2
+++ b/rambo/vagrant_resources/vagrantfiles/ec2
@@ -15,11 +15,11 @@ Vagrant.configure("2") do |config|
     provider.availability_zone = "us-west-1c"
     provider.region = "us-west-1"
     provider.ami = "ami-a5d621e1"
-    if ENV"[RAMBO_RAM"] == "512"
+    if ENV[PROJECT_NAME + "_RAM"] == "512"
       provider.instance_type = "t2.nano"
-    elsif ENV"[RAMBO_RAM"] == "1024"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "1024"
       provider.instance_type = "t2.micro"
-    elsif ENV"[RAMBO_RAM"] == "2048"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "2048"
       provider.instance_type = "t2.small"
     end
     provider.block_device_mapping = [{

--- a/rambo/vagrant_resources/vagrantfiles/lxc
+++ b/rambo/vagrant_resources/vagrantfiles/lxc
@@ -4,17 +4,17 @@
 Vagrant.configure("2") do |config|
   config.vm.provider :lxc do |provider|
     provider.backingstore = "loop"
-    if VM_RAM == "512"
+    if ENV["RAMBO_RAM"] == "512"
       provider.customize "cgroup.memory.limit_in_bytes",
         "512M"
       provider.backingstore_option "--fssize",
         "20G"
-    elsif VM_RAM == "1024"
+    elsif ENV["RAMBO_RAM"] == "1024"
       provider.customize "cgroup.memory.limit_in_bytes",
         "1024M"
       provider.backingstore_option "--fssize",
         "30G"
-    elsif VM_RAM == "2048"
+    elsif ENV["RAMBO_RAM"] == "2048"
       provider.customize "cgroup.memory.limit_in_bytes",
         "2048M"
       provider.backingstore_option "--fssize",

--- a/rambo/vagrant_resources/vagrantfiles/lxc
+++ b/rambo/vagrant_resources/vagrantfiles/lxc
@@ -4,17 +4,17 @@
 Vagrant.configure("2") do |config|
   config.vm.provider :lxc do |provider|
     provider.backingstore = "loop"
-    if VM_SIZE == "512mb"
+    if VM_RAM == "512"
       provider.customize "cgroup.memory.limit_in_bytes",
         "512M"
       provider.backingstore_option "--fssize",
         "20G"
-    elsif VM_SIZE == "1024mb"
+    elsif VM_RAM == "1024"
       provider.customize "cgroup.memory.limit_in_bytes",
         "1024M"
       provider.backingstore_option "--fssize",
         "30G"
-    elsif VM_SIZE == "2048mb"
+    elsif VM_RAM == "2048"
       provider.customize "cgroup.memory.limit_in_bytes",
         "2048M"
       provider.backingstore_option "--fssize",

--- a/rambo/vagrant_resources/vagrantfiles/lxc
+++ b/rambo/vagrant_resources/vagrantfiles/lxc
@@ -4,17 +4,17 @@
 Vagrant.configure("2") do |config|
   config.vm.provider :lxc do |provider|
     provider.backingstore = "loop"
-    if ENV["RAMBO_RAM"] == "512"
+    if ENV[PROJECT_NAME + "_RAM"] == "512"
       provider.customize "cgroup.memory.limit_in_bytes",
         "512M"
       provider.backingstore_option "--fssize",
         "20G"
-    elsif ENV["RAMBO_RAM"] == "1024"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "1024"
       provider.customize "cgroup.memory.limit_in_bytes",
         "1024M"
       provider.backingstore_option "--fssize",
         "30G"
-    elsif ENV["RAMBO_RAM"] == "2048"
+    elsif ENV[PROJECT_NAME + "_RAM"] == "2048"
       provider.customize "cgroup.memory.limit_in_bytes",
         "2048M"
       provider.backingstore_option "--fssize",
@@ -32,6 +32,6 @@ Vagrant.configure("2") do |config|
     :guest => 80,
     :host => 8080,
     auto_correct: true
-  config.vm.box = "terminal-labs/tl-debian-8-64bit-lxc"
-  config.vm.box_url = "terminal-labs/tl-debian-8-64bit-lxc"
+  config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-lxc"
+  config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-lxc"
 end

--- a/rambo/vagrant_resources/vagrantfiles/virtualbox
+++ b/rambo/vagrant_resources/vagrantfiles/virtualbox
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider|
     # set unique vm name
     provider.name = VM_NAME
-      provider.memory = ENV["RAMBO_RAM"]
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV["RAMBO_DRIVESIZE"]
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV["RAMBO_DRIVESIZE"]
+      provider.memory = ENV[PROJECT_NAME + "_RAM"]
+      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV[PROJECT_NAME + "_DRIVESIZE"]
+      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV[PROJECT_NAME + "_DRIVESIZE"]
 
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']

--- a/rambo/vagrant_resources/vagrantfiles/virtualbox
+++ b/rambo/vagrant_resources/vagrantfiles/virtualbox
@@ -5,27 +5,10 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider|
     # set unique vm name
     provider.name = VM_NAME
-    if VM_SIZE == "512mb"
-      provider.memory = 512
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-20gb"
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-20gb"
-    elsif VM_SIZE == "1024mb"
-      provider.memory = 1024
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-30gb"
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-30gb"
-    elsif VM_SIZE == "2048mb"
-      provider.memory = 2048
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-40gb"
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-40gb"
-    elsif VM_SIZE == "4096mb"
-      provider.memory = 4096
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-60gb"
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-60gb"
-    elsif VM_SIZE == "8192mb"
-      provider.memory = 8192
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-80gb"
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-80gb"
-    end
+      provider.memory = VM_RAM
+      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-" + VM_HARDDRIVE
+      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-" + VM_HARDDRIVE
+
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']
   end

--- a/rambo/vagrant_resources/vagrantfiles/virtualbox
+++ b/rambo/vagrant_resources/vagrantfiles/virtualbox
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |provider|
     # set unique vm name
     provider.name = VM_NAME
-      provider.memory = VM_RAM
-      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-" + VM_HARDDRIVE
-      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-" + VM_HARDDRIVE
+      provider.memory = ENV["RAMBO_RAM"]
+      config.vm.box = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV["RAMBO_DRIVESIZE"]
+      config.vm.box_url = "terminal-labs/tl-" + VM_HOST + "-64bit-" + ENV["RAMBO_DRIVESIZE"]
 
     provider.customize ['modifyvm', :id, '--nictype1', 'virtio']
     provider.customize ['modifyvm', :id, '--nictype2', 'virtio']


### PR DESCRIPTION
1) Changed VM_SIZE to VM_RAM
2) VM_HARDDRIVE created for box url parsing
3) VM_RAM & VM_HARDDRIVE are key-value paired
4) VM_RAM vairable now is strictly numerical without the "mb" suffix
5) Redundant code in virtualbox vagrant file reduced

Resolves issue #173 