### PR TITLE
[rambo-224] Fixes #224. We weren't passing the right data to vagrant.

### DIFF
--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -81,8 +81,9 @@ def gen():
     click.echo("Warning -- you entered a command %s does not understand. "
                "Passing raw commands to Vagrant backend" % PROJECT_NAME.capitalize())
     click.echo('You ran "%s"' % ' '.join(sys.argv))
+    sys.argv.pop(0) # Remove Rambo path from full command
     click.echo('Vagrant backend says:')
-    vagrant_general_command(sys.argv.pop(0))
+    vagrant_general_command(' '.join(sys.argv))
 
 ### Subcommands
 @cli.command('createproject')


### PR DESCRIPTION
Ref fixes #224.

Test cases `rambo plugin list` and `rambo plugin -v` perform as expected, i.e., the same as `vagrant plugin list` and `vagrant plugin -v`.

This does not need reflected in the changelog since the bug this fixes was introduced after the last release.