### PR TITLE
Making config file usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project uses Vagrant and Vagrant plugins for some of the heavy lifting, and
 By default Rambo offers a basic provisioning, but you can customize this. See [**Advanced Usage**](#advanced-usage) for that.
 
 ## Basic Usage
-Rambo needs to be installed first. It is a Python package, and can be installed in an Conda or Virtualenv environment with `pip install rambo-vagrant`, or the development version (this repo) can be installed with `pip install -e .`. Some providers will need a more configuration for things like key managment (see: [INSTALL.md](https://github.com/terminal-labs/rambo/blob/master/docs/INSTALL.md)). Once installed, you can run one of these commands to get your VM:
+Rambo needs to be installed first. It is a Python package, and can be installed in an Conda or Virtualenv environment with `pip install rambo-vagrant`, or the development version (this repo) can be installed with `pip install -e . --process-dependency-links`. Some providers will need a more configuration for things like key managment (see: [INSTALL.md](https://github.com/terminal-labs/rambo/blob/master/docs/INSTALL.md)). Once installed, you can run one of these commands to get your VM:
 
 for VirtualBox run
 ```

--- a/rambo/Vagrantfile
+++ b/rambo/Vagrantfile
@@ -100,7 +100,9 @@ custom_code_dirs = [
 # Provisioning
 Vagrant.configure("2") do |config|
   if get_env_var_rb('SYNC') != 'disabled'
-    config.vm.synced_folder '.', "/vagrant", type: get_env_var_rb('SYNC')
+    config.vm.synced_folder '.', "/vagrant",
+      type: get_env_var_rb('SYNC'),
+      rsync__exclude: ['saltstack/'] # only provisioning code in project dir
     for custom_code_dir in custom_code_dirs
       if Dir.exist?(File.join(get_env_var_rb("CWD"), custom_code_dir))
         config.vm.synced_folder File.join(get_env_var_rb("CWD"), custom_code_dir),
@@ -115,7 +117,7 @@ Vagrant.configure("2") do |config|
       inline: "if [ -f /etc/apt/sources.list ]; then wget -O /etc/apt/sources.list https://raw.githubusercontent.com/terminal-labs/package-sources/master/" + get_env_var_rb("GUEST_OS") + "/official/sources.list; fi",
       keep_color: true
   end
-  if PROVISION_WITH_SALT
+  if PROVISION_WITH_SALT and Dir.exist?(File.join(get_env_var_rb("CWD"), 'saltstack'))
     config.vm.provision :salt do |salt|
       salt.bootstrap_options = "-P"
       salt.verbose = true
@@ -148,6 +150,9 @@ end
 
 # clean up files on the host after the guest is destroyed
 Vagrant.configure("2") do |config|
+  config.trigger.after :up do
+    puts "Vagrant done with up."
+  end
   config.trigger.after :destroy do
     puts "Vagrant done with destroy."
   end

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -312,7 +312,8 @@ def install_config(ctx=None, output_path=None):
         abort('rambo.conf already esists.')
     else:
         with open(path, 'w') as f:
-            f.write('[up]\nprovider = virtualboxsadf\nguest_os = ubuntu-1604\n')
+            f.write('[up]\nprovider = %s\nguest_os = %s\n'
+                    % (SETTINGS['PROVIDERS_DEFAULT'], SETTINGS['GUEST_OSES_DEFAULT']))
         click.echo('Created config at %s' % path)
 
 def install_plugins(force=None, plugins=('all',)):

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -263,6 +263,7 @@ def setup():
     '''Install all default plugins and setup auth directory.
     '''
     install_auth()
+    install_config()
     install_plugins()
 
 def install_auth(ctx=None, output_path=None):
@@ -296,6 +297,23 @@ def install_auth(ctx=None, output_path=None):
     # in env vars, and set them. This is an avenue for expanding the cli/api's use
     # and not needing the auth key scripts.
     # load_provider_keys()
+
+def install_config(ctx=None, output_path=None):
+    '''Install config file.
+    '''
+    if not ctx: # Using API. Else handled by cli.
+        set_init_vars()
+
+    if not output_path:
+        output_path = get_env_var('cwd')
+    path = os.path.join(output_path, 'rambo.conf')
+
+    if os.path.exists(path):
+        abort('rambo.conf already esists.')
+    else:
+        with open(path, 'w') as f:
+            f.write('[up]\nprovider = virtualboxsadf\nguest_os = ubuntu-1604\n')
+        click.echo('Created config at %s' % path)
 
 def install_plugins(force=None, plugins=('all',)):
     '''Install all of the vagrant plugins needed for all plugins

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -26,9 +26,8 @@ from rambo.utils import abort, get_user_home, set_env_var, get_env_var, dir_exis
 PROJECT_LOCATION = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(PROJECT_LOCATION, 'settings.json'), 'r') as f:
     SETTINGS = json.load(f)
-PROVIDERS = SETTINGS['PROVIDERS']
 PROJECT_NAME = SETTINGS['PROJECT_NAME']
-GUEST_OSES = SETTINGS['GUEST_OSES']
+
 def write_to_log(data=None, file_name=None):
     '''Write data to log files. Will append data to a single combined log.
     Additionally write data to a log with a custom name (such as stderr)

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -306,10 +306,10 @@ def install_config(ctx=None, output_path=None):
 
     if not output_path:
         output_path = get_env_var('cwd')
-    path = os.path.join(output_path, 'rambo.conf')
+    path = os.path.join(output_path, '%s.conf' % PROJECT_NAME)
 
     if os.path.exists(path):
-        abort('rambo.conf already esists.')
+        abort('%s.conf already esists.' % PROJECT_NAME)
     else:
         with open(path, 'w') as f:
             f.write('[up]\nprovider = %s\nguest_os = %s\n'

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -365,12 +365,10 @@ def up(ctx=None, provider=None,  guest_os=None, vagrant_cwd=None, vagrant_dotfil
         set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
     ## provider
-    if provider: # overwrite possible env var regardless. It gets lowest priority.
-        set_env_var('provider', provider)
-    elif get_env_var('provider'):
-        provider = get_env_var('provider')
-    elif provider == "":
+    if not provider:
         provider = SETTINGS['PROVIDERS_DEFAULT']
+    set_env_var('provider', provider)
+
     if provider not in SETTINGS['PROVIDERS']:
         msg = ('Provider "%s" is not in the provider list.\n'
                'Did you have a typo? Here is as list of avalible providers:\n\n'
@@ -380,12 +378,10 @@ def up(ctx=None, provider=None,  guest_os=None, vagrant_cwd=None, vagrant_dotfil
         abort(msg)
 
     ## guest_os
-    if guest_os: # overwrite possible env var regardless. It gets lowest priority.
-        set_env_var('guest_os', str(guest_os))
-    elif get_env_var('guest_os'):
-        guest_os = get_env_var('guest_os')
-    elif guest_os == "":
+    if not guest_os:
         guest_os = SETTINGS['GUEST_OSES_DEFAULT']
+    set_env_var('guest_os', str(guest_os))
+
     if guest_os not in SETTINGS['GUEST_OSES']:
         msg = ('Guest OS "%s" is not in the guest OSes list.\n'
                'Did you have a typo? Here is as list of avalible guest OSes:\n\n'

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -364,21 +364,35 @@ def up(ctx=None, provider=None,  guest_os=None, vagrant_cwd=None, vagrant_dotfil
         set_init_vars()
         set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
-    if provider: # if none, keep unset
+    ## provider
+    if provider: # overwrite possible env var regardless. It gets lowest priority.
         set_env_var('provider', provider)
-        if provider not in PROVIDERS:
-            abort('Target provider "%s" is not in the providers '
-                  'list. Did you have a typo?' % provider)
+    elif get_env_var('provider'):
+        provider = get_env_var('provider')
+    elif provider == "":
+        provider = SETTINGS['PROVIDERS_DEFAULT']
+    if provider not in SETTINGS['PROVIDERS']:
+        msg = ('Provider "%s" is not in the provider list.\n'
+               'Did you have a typo? Here is as list of avalible providers:\n\n'
+               % provider)
+        for supported_provider in SETTINGS['PROVIDERS']:
+            msg = msg + '%s\n' % supported_provider
+        abort(msg)
 
-    if guest_os: # if none, keep unset
+    ## guest_os
+    if guest_os: # overwrite possible env var regardless. It gets lowest priority.
         set_env_var('guest_os', str(guest_os))
-        if guest_os not in GUEST_OSES:
-            msg = ('Guest OS "{}" is not in the guest OSes list.\n'
-                   'Did you have a typo? Here is as list of avalible guest OSes:\n')
-            msg = msg.format(guest_os)
-            for os in GUEST_OSES:
-                msg = msg + '{}\n'.format(os)
-            abort(msg)
+    elif get_env_var('guest_os'):
+        guest_os = get_env_var('guest_os')
+    elif guest_os == "":
+        guest_os = SETTINGS['GUEST_OSES_DEFAULT']
+    if guest_os not in SETTINGS['GUEST_OSES']:
+        msg = ('Guest OS "%s" is not in the guest OSes list.\n'
+               'Did you have a typo? Here is as list of avalible guest OSes:\n\n'
+               % guest_os)
+        for supported_os in SETTINGS['GUEST_OSES']:
+            msg = msg + '%s\n' % supported_os
+        abort(msg)
 
     _invoke_vagrant('up')
 

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -171,6 +171,7 @@ def createproject(project_name, config_only=None):
     if not config_only:
         export('saltstack', path)
         install_auth(output_path=path)
+        install_config(output_path=path)
 
 
 def destroy(ctx=None, vagrant_cwd=None, vagrant_dotfile_path=None):

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -373,7 +373,8 @@ def up(ctx=None, provider=None,  guest_os=None, vagrant_cwd=None, vagrant_dotfil
     if guest_os: # if none, keep unset
         set_env_var('guest_os', str(guest_os))
         if guest_os not in GUEST_OSES:
-            msg = 'Guest OS "{}" is not in the guest OSes list. Did you have a typo? Here is as list of avalible guest OSes:\n'
+            msg = ('Guest OS "{}" is not in the guest OSes list.\n'
+                   'Did you have a typo? Here is as list of avalible guest OSes:\n')
             msg = msg.format(guest_os)
             for os in GUEST_OSES:
                 msg = msg + '{}\n'.format(os)

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -181,6 +181,11 @@ def ssh_cmd(ctx):
 def up_cmd(ctx, provider, guest_os):
     '''Start a VM / container with `vagrant up`.
     '''
+    if ctx.default_map['up']['provider'] and not provider:
+        provider = ctx.default_map['up']['provider']
+    if ctx.default_map['up']['guest_os'] and not guest_os:
+        guest_os = ctx.default_map['up']['guest_os']
+
     up(ctx, provider, guest_os)
 
 ### Sub-subcommands

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -55,8 +55,14 @@ class ConfigSectionSchema(object):
 class ConfigFileProcessor(ConfigFileReader):
     config_files = ['rambo.conf']
     config_section_schemas = [
+        # Don't move the first line. It brings with it easy use with
+        # CLI > Configuration file > Environment > Default, by default.
+        # This is because it is merged into default_map's top level.
+        # Other section schemas need handled manually. They are added
+        # to default_map[schemaname].
+        ConfigSectionSchema.Up, # PRIMARY SCHEMA
         ConfigSectionSchema.Base,
-        ConfigSectionSchema.Up,
+
     ]
 
 ### BASE COMMAND LIST
@@ -181,11 +187,6 @@ def ssh_cmd(ctx):
 def up_cmd(ctx, provider, guest_os):
     '''Start a VM / container with `vagrant up`.
     '''
-    if ctx.default_map['up']['provider'] and not provider:
-        provider = ctx.default_map['up']['provider']
-    if ctx.default_map['up']['guest_os'] and not guest_os:
-        guest_os = ctx.default_map['up']['guest_os']
-
     up(ctx, provider, guest_os)
 
 ### Sub-subcommands

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -14,6 +14,7 @@ from rambo.app import (
     export,
     setup,
     install_auth,
+    install_config,
     install_plugins,
     set_init_vars,
     set_vagrant_vars,
@@ -52,7 +53,7 @@ class ConfigSectionSchema(object):
         guest_os    = Param(type=str)
 
 class ConfigFileProcessor(ConfigFileReader):
-    config_files = ['rambo.ini', 'rambo.cfg', 'rambo.conf']
+    config_files = ['rambo.conf']
     config_section_schemas = [
         ConfigSectionSchema.Base,
         ConfigSectionSchema.Up,

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -84,6 +84,7 @@ BASECMD_CONTEXT_SETTINGS = {
 CONTEXT_SETTINGS = {
     'help_option_names': ['-h', '--help'],
     'default_map': ConfigFileProcessor.read_config(),
+    'auto_envvar_prefix': PROJECT_NAME.upper()
 }
 
 ### Main command / CLI entry point
@@ -177,11 +178,11 @@ def ssh_cmd(ctx):
     ssh(ctx)
 
 @cli.command('up', context_settings=CONTEXT_SETTINGS)
-@click.option('-p', '--provider', envvar = PROJECT_NAME.upper() + '_PROVIDER',
+@click.option('-p', '--provider',
               help='Provider for the virtual machine. '
               'These providers are supported: %s. Default %s.'
               % (SETTINGS['PROVIDERS'], SETTINGS['PROVIDERS_DEFAULT']))
-@click.option('-o', '--guest-os', envvar = PROJECT_NAME.upper() + '_GUEST_OS',
+@click.option('-o', '--guest-os',
               help='Operating System of the guest, inside the virtual machine. '
               'These guest OSs are supported: %s. Default %s.'
               % (SETTINGS['GUEST_OSES'], SETTINGS['GUEST_OSES_DEFAULT']))

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -54,16 +54,14 @@ class ConfigSectionSchema(object):
 
 class ConfigFileProcessor(ConfigFileReader):
     config_files = ['rambo.conf']
-    config_section_schemas = [
-        # Don't move the first line. It brings with it easy use with
-        # CLI > Configuration file > Environment > Default, by default.
-        # This is because it is merged into default_map's top level.
-        # Other section schemas need handled manually. They are added
-        # to default_map[schemaname].
-        ConfigSectionSchema.Up, # PRIMARY SCHEMA
+    # Specify additional schemas to merge with the primary so that they
+    # are added to the top level of default_map, for easy precedence of
+    # CLI > Configuration file > Environment > Default.
+    config_section_primary_schemas = [
         ConfigSectionSchema.Base,
-
+        ConfigSectionSchema.Up,
     ]
+    config_section_schemas = config_section_primary_schemas
 
 ### BASE COMMAND LIST
 cmd = ''
@@ -109,6 +107,10 @@ CONTEXT_SETTINGS = {
 @click.version_option(prog_name=PROJECT_NAME.capitalize(), version=version)
 @click.pass_context
 def cli(ctx, cwd, tmpdir_path, vagrant_cwd, vagrant_dotfile_path):
+    '''The main cli entry point. Params can be passed as usual with
+    click (CLI or env var) and also with an INI config file.
+    Precedence is CLI > Config > Env Var > defaults.
+    '''
     # These need to be very early because they may change the cwd of this Python or of Vagrant
     set_init_vars(cwd, tmpdir_path)
     set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
@@ -182,10 +184,13 @@ def ssh_cmd(ctx):
               'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
 @click.option('-o', '--guest-os', envvar = PROJECT_NAME.upper() + '_GUEST_OS',
               help='Operating System of the guest, inside the virtual machine. '
-              'These guest OSs are supported: %s. Default Ubuntu.' % GUEST_OSES)
+              'These guest OSs are supported: %s. Default Ubuntu-1604.' % GUEST_OSES)
 @click.pass_context
 def up_cmd(ctx, provider, guest_os):
     '''Start a VM / container with `vagrant up`.
+    Params can be passed as usual with
+    click (CLI or env var) and also with an INI config file.
+    Precedence is CLI > Config > Env Var > defaults.
     '''
     up(ctx, provider, guest_os)
 

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -30,8 +30,6 @@ from rambo.app import (
 PROJECT_LOCATION = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(PROJECT_LOCATION, 'settings.json'), 'r') as f:
     SETTINGS = json.load(f)
-PROVIDERS = SETTINGS['PROVIDERS']
-GUEST_OSES = SETTINGS['GUEST_OSES']
 PROJECT_NAME = SETTINGS['PROJECT_NAME']
 
 version = pkg_resources.get_distribution('rambo-vagrant').version
@@ -181,10 +179,12 @@ def ssh_cmd(ctx):
 @cli.command('up', context_settings=CONTEXT_SETTINGS)
 @click.option('-p', '--provider', envvar = PROJECT_NAME.upper() + '_PROVIDER',
               help='Provider for the virtual machine. '
-              'These providers are supported: %s. Default virtualbox.' % PROVIDERS)
+              'These providers are supported: %s. Default %s.'
+              % (SETTINGS['PROVIDERS'], SETTINGS['PROVIDERS_DEFAULT']))
 @click.option('-o', '--guest-os', envvar = PROJECT_NAME.upper() + '_GUEST_OS',
               help='Operating System of the guest, inside the virtual machine. '
-              'These guest OSs are supported: %s. Default Ubuntu-1604.' % GUEST_OSES)
+              'These guest OSs are supported: %s. Default %s.'
+              % (SETTINGS['GUEST_OSES'], SETTINGS['GUEST_OSES_DEFAULT']))
 @click.pass_context
 def up_cmd(ctx, provider, guest_os):
     '''Start a VM / container with `vagrant up`.

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -53,7 +53,7 @@ class ConfigSectionSchema(object):
         guest_os    = Param(type=str)
 
 class ConfigFileProcessor(ConfigFileReader):
-    config_files = ['rambo.conf']
+    config_files = ['%s.conf' % PROJECT_NAME]
     # Specify additional schemas to merge with the primary so that they
     # are added to the top level of default_map, for easy precedence of
     # CLI > Configuration file > Environment > Default.
@@ -192,6 +192,11 @@ def up_cmd(ctx, provider, guest_os):
     click (CLI or env var) and also with an INI config file.
     Precedence is CLI > Config > Env Var > defaults.
     '''
+    if not os.path.isfile('%s.conf' % PROJECT_NAME):
+        abort("Config file %s.conf must be present in working directory.\n"
+              "You can create one with `%s setup config`." %
+              (PROJECT_NAME, PROJECT_NAME))
+
     up(ctx, provider, guest_os)
 
 ### Sub-subcommands

--- a/rambo/settings.json
+++ b/rambo/settings.json
@@ -25,11 +25,12 @@
         "lxc",
         "virtualbox"
     ],
+    "PROVIDERS_DEFAULT": "virtualbox",
     "GUEST_OSES": [
         "debian-8",
         "ubuntu-1404",
         "ubuntu-1604",
         "centos-7"
-    ]
-
+    ],
+    "GUEST_OSES_DEFAULT": "ubuntu-1604"
 }

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'termcolor'
     ],
     dependency_links=[
-        'https://github.com/terminal-labs/click-configfile/archive/28c5d53ea7551dac2227d8010f468443864e5aea.zip#egg=click-configfile-1',
+        'https://github.com/terminal-labs/click-configfile/archive/38a0831efff0c37678de595b9fbfd65ed1baba3b.zip#egg=click-configfile-1',
     ],
     cmdclass={
         'install': CustomInstallCommand,

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'termcolor'
     ],
     dependency_links=[
-        'https://github.com/terminal-labs/click-configfile/archive/38a0831efff0c37678de595b9fbfd65ed1baba3b.zip#egg=click-configfile-1',
+        'https://github.com/terminal-labs/click-configfile/archive/merge-with-primary-schema.zip#egg=click-configfile-1',
     ],
     cmdclass={
         'install': CustomInstallCommand,

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'click',
+        'click-configfile',
         'termcolor'
     ],
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,11 @@ setup(
     zip_safe=False,
     install_requires=[
         'click',
-        'click-configfile',
+        'click-configfile<=1'
         'termcolor'
+    ],
+    dependency_links=[
+        'https://github.com/terminal-labs/click-configfile/archive/28c5d53ea7551dac2227d8010f468443864e5aea.zip#egg=click-configfile-1',
     ],
     cmdclass={
         'install': CustomInstallCommand,

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'click',
-        'click-configfile<=1'
+        'click-configfile<=1',
         'termcolor'
     ],
     dependency_links=[


### PR DESCRIPTION
Fixes #214 

- Making `rambo setup config` / `install_config`
- Dropping config with createproject
- Making config's existence mandatory
- Now only using salt code from the saltstack dir in the project if it exists

This uses our custom fork of click-configfile: https://github.com/terminal-labs/click-configfile