### PR TITLE
Refactored vagrant passthrough

### DIFF
--- a/rambo/app.py
+++ b/rambo/app.py
@@ -466,15 +466,14 @@ def up(ctx=None, provider=None,  guest_os=None, ram_size=None, drive_size=None,
     ## Add straight pass-through flags. Keep test for True/False explicit as only those values should work
     cmd = 'up'
     if provision is True:
-        cmd = ' '.join([cmd, '--provision'])
+        cmd = '{} {}'.format(cmd, '--provision')
     elif provision is False:
-        cmd = ' '.join([cmd, '--no-provision'])
+        cmd = '{} {}'.format(cmd, '--no-provision')
 
     if destroy_on_error is True:
-        cmd = ' '.join([cmd, '--destroy-on-error'])
+        cmd = '{} {}'.format(cmd, '--destroy-on-error')
     elif destroy_on_error is False:
-        cmd = ' '.join([cmd, '--no-destroy-on-error'])
-
+        cmd = '{} {}'.format(cmd, '--no-destroy-on-error')
 
     _invoke_vagrant(cmd)
 

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -465,12 +465,11 @@ def up(ctx=None, provider=None,  guest_os=None, ram_size=None, drive_size=None,
 
     ## Add straight pass-through flags. Keep test for True/False explicit as only those values should work
     cmd = 'up'
-    # `vagrant up` provisioning flag
     if provision is True:
         cmd = ' '.join([cmd, '--provision'])
     elif provision is False:
         cmd = ' '.join([cmd, '--no-provision'])
-    # `vagrant up` destroy-on-error flag
+
     if destroy_on_error is True:
         cmd = ' '.join([cmd, '--destroy-on-error'])
     elif destroy_on_error is False:

--- a/rambo/app.py
+++ b/rambo/app.py
@@ -325,12 +325,13 @@ def install_plugins(force=None, plugins=('all',)):
                           'to install anyway?' % plugin, abort=True)
             _invoke_vagrant('plugin install %s' % plugin)
 
-def ssh(ctx=None, vagrant_cwd=None, vagrant_dotfile_path=None):
+def ssh(ctx=None, command=None, vagrant_cwd=None, vagrant_dotfile_path=None):
     '''Connect to an running VM / container over ssh.
     All str args can also be set as an environment variable; arg takes precedence.
 
     Agrs:
         ctx (object): Click Context object.
+        command (str): Pass-through command to run with `vagrant ssh --command`.
         vagrant_cwd (path): Location of `Vagrantfile`. Used if invoked with API only.
         vagrant_dotfile_path (path): Location of `.vagrant` metadata directory. Used if invoked with API only.
     '''
@@ -339,7 +340,13 @@ def ssh(ctx=None, vagrant_cwd=None, vagrant_dotfile_path=None):
         set_init_vars()
         set_vagrant_vars(vagrant_cwd, vagrant_dotfile_path)
 
-    os.system('vagrant ssh')
+    ## Add pass-through 'command' option.
+    cmd = 'vagrant ssh'
+    if command:
+        cmd = ' '.join([cmd, '--command', command])
+
+    # do not use _invoke_vagrant, that will give a persistent ssh session regardless.
+    os.system(cmd)
 
 def up(ctx=None, provider=None,  guest_os=None, ram_size=None, drive_size=None,
        machine_type=None, provision=None, destroy_on_error=None,

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -30,11 +30,13 @@ class ConfigSectionSchema(object):
     @matches_section('up')
     class Up(SectionSchema):
         '''Corresponds to the `up` command group.'''
-        provider      = Param(type=str)
-        guest_os      = Param(type=str)
-        ram_size      = Param(type=int)
-        drive_size    = Param(type=int)
-        machine_type  = Param(type=str)
+        provider           = Param(type=str)
+        guest_os           = Param(type=str)
+        ram_size           = Param(type=int)
+        drive_size         = Param(type=int)
+        machine_type       = Param(type=str)
+        provision          = Param(type=bool)
+        destroy_on_error   = Param(type=bool)
 
 
 class ConfigFileProcessor(ConfigFileReader):
@@ -50,7 +52,7 @@ class ConfigFileProcessor(ConfigFileReader):
 
 
 # Only used for the `vagrant` subcommand
-HANDLE_EXTRA_ARGS = {
+VAGRANT_CMD_CONTEXT_SETTINGS = {
     'ignore_unknown_options': True,
     'allow_extra_args': True,
 }
@@ -167,8 +169,11 @@ def ssh_cmd(ctx):
 @click.option('-m', '--machine-type', type=str,
               help='Machine type for cloud providers.\n'
               'E.g. m5.medium for ec2, or s-8vcpu-32gb for digitalocean.\n')
+@click.option('--provision/--no-provision', default=None)
+@click.option('--destroy-on-error/--no-destroy-on-error', default=None)
 @click.pass_context
-def up_cmd(ctx, provider, guest_os, ram_size, drive_size, machine_type):
+def up_cmd(ctx, provider, guest_os, ram_size, drive_size, machine_type,
+           provision, destroy_on_error):
     '''Start a VM / container with `vagrant up`.
     Params can be passed as usual with
     click (CLI or env var) and also with an INI config file.
@@ -180,9 +185,10 @@ def up_cmd(ctx, provider, guest_os, ram_size, drive_size, machine_type):
               'createproject. You can also make a config file manually.'
               % PROJECT_NAME)
 
-    app.up(ctx, provider, guest_os, ram_size, drive_size, machine_type)
+    app.up(ctx, provider, guest_os, ram_size, drive_size, machine_type,
+           provision, destroy_on_error)
 
-@cli.command('vagrant', context_settings=dict(CONTEXT_SETTINGS, **HANDLE_EXTRA_ARGS))
+@cli.command('vagrant', context_settings=VAGRANT_CMD_CONTEXT_SETTINGS)
 @click.pass_context
 def vagrant_cmd(ctx):
     '''Run a vagrant command through rambo.

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -139,11 +139,13 @@ def install_plugins(force, plugins):
 
 
 @cli.command('ssh', short_help="Connect with `vagrant ssh`")
+@click.option('-c', '--command', type=str,
+              help='Execute an SSH command directly')
 @click.pass_context
-def ssh_cmd(ctx):
+def ssh_cmd(ctx, command):
     '''Connect to an running VM / container over ssh with `vagrant ssh`.
     '''
-    app.ssh(ctx)
+    app.ssh(ctx, command)
 
 
 @cli.command('up', context_settings=CONTEXT_SETTINGS)
@@ -169,8 +171,10 @@ def ssh_cmd(ctx):
 @click.option('-m', '--machine-type', type=str,
               help='Machine type for cloud providers.\n'
               'E.g. m5.medium for ec2, or s-8vcpu-32gb for digitalocean.\n')
-@click.option('--provision/--no-provision', default=None)
-@click.option('--destroy-on-error/--no-destroy-on-error', default=None)
+@click.option('--provision/--no-provision', default=None,
+              help='Enable or disable provisioning')
+@click.option('--destroy-on-error/--no-destroy-on-error', default=None,
+              help='Destroy machine if any fatal error happens (default to true)')
 @click.pass_context
 def up_cmd(ctx, provider, guest_os, ram_size, drive_size, machine_type,
            provision, destroy_on_error):


### PR DESCRIPTION
Resolves #261 

Addes `rambo vagrant` command which is a simple and explicit passthrough of everything the follows that command. The exception are click's eager options for help/verbosity.

E.g. `rambo vagrant scp [source] [target]`

Also adds the passthrough options for 
- `up --[no-]provision` (also added as conf var)
- `up --[no-]destroy-on-error` (also added as conf var)
- `ssh -c [args]` / `ssh --command [args]

### I want to point out
that I am now excited by the combination of the number of options we have and the conf file. I can easily toggle conf vars on/off with a `#`. I have `provision = false` and ` destroy_on_error = false` set for my development now most of the time and it's bliss. I want more :D