### PR TITLE
[rambo-296] Remaking conf file sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- Remaking conf file sections into more granular and intuitive sections.
 - Now you can pass fancy pathing like `..` and symlinks to the CLI.
 - More comprehensive logging.
 

--- a/rambo/cli.py
+++ b/rambo/cli.py
@@ -24,21 +24,30 @@ class ConfigSectionSchema(object):
     class Base(SectionSchema):
         '''Corresponds to the main CLI entry point.'''
         cwd                   = Param(type=click.Path())
+        destroy_on_error      = Param(type=bool)
         tmpdir_path           = Param(type=click.Path())
         vagrant_cwd           = Param(type=click.Path())
         vagrant_dotfile_path  = Param(type=click.Path())
 
-    @matches_section('up')
-    class Up(SectionSchema):
-        '''Corresponds to the `up` command group.'''
-        provider           = Param(type=str)
-        guest_os           = Param(type=str)
+    @matches_section('configuration_management')
+    class ConfigurationManagement(SectionSchema):
+        sync_dir           = Param(type=click.Path())
+        provision          = Param(type=bool)
+
+    @matches_section('hardware')
+    class Hardware(SectionSchema):
         ram_size           = Param(type=int)
         drive_size         = Param(type=int)
         machine_type       = Param(type=str)
-        sync_dir           = Param(type=click.Path())
-        provision          = Param(type=bool)
-        destroy_on_error   = Param(type=bool)
+
+    @matches_section('networking')
+    class Networking(SectionSchema):
+        pass # fill later after we have networking options
+
+    @matches_section('provider')
+    class Provider(SectionSchema):
+        provider           = Param(type=str)
+        guest_os           = Param(type=str)
 
 
 class ConfigFileProcessor(ConfigFileReader):
@@ -48,7 +57,10 @@ class ConfigFileProcessor(ConfigFileReader):
     # CLI > Configuration file > Environment > Default.
     config_section_primary_schemas = [
         ConfigSectionSchema.Base,
-        ConfigSectionSchema.Up,
+        ConfigSectionSchema.ConfigurationManagement,
+        ConfigSectionSchema.Hardware,
+        ConfigSectionSchema.Networking,
+        ConfigSectionSchema.Provider,
     ]
     config_section_schemas = config_section_primary_schemas
 


### PR DESCRIPTION
**(issue reference)**
Fixes #296 (I accidentally named the branch rambo-263 - which is unrelated. whoops)

**Does this deserve / include a changlog entry?** Included

Sample rambo.conf to work with this:
```ini
[configuration_management]                                                          
provision = false                                                                   
                                                                                    
[provider]                                                                          
provider = virtualbox                                                               
guest-os = ubuntu-1604                                                              
                                                                                    
[hardware]                                                                          
ram_size = 500 
```
This is a first attempt at a more granular section breakdown. It may be fine, or maybe we can come up with something better. For instance, I put `machine_type` in `hardware`, where I could also see it fitting into `provider` just as well. @smitty42 I think you might have an opinion on this.