### PR TITLE
[rambo-299+rambo-212] guest hostname generation fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ IMPROVEMENTS:
 
 BUGFIX:
 
+- Fixes guest hostname generation when given underscores in the path, casting it to "95", it's ascii code.
+- Fixes guest hostname generation when too long, truncating the part preceding the hash so total length stays below 64 chars.
 - Fix bug when setting machine-type.
 - Fix ability to set cwd.
 

--- a/rambo/vagrant/modules.rb
+++ b/rambo/vagrant/modules.rb
@@ -8,7 +8,10 @@ def random_tag
   if File.file?(random_tag_path)
     tag = File.read(random_tag_path)
   else
-    tag = host + '-' + File.basename(File.dirname(tmp_dir)) + '-' + SecureRandom.hex(6)
+    # 95 is unlikely to be used. It is the ascii code for an underscore
+    guest_hostname = host + '-' + File.basename(File.dirname(tmp_dir)).sub("_", "95")
+    guest_hostname = truncate(guest_hostname, 43) # 64 - 15 for the next line - 6 for "rambo-"
+    tag = guest_hostname + '-' + SecureRandom.hex(6)
     File.write(random_tag_path, tag)
   end
   return tag
@@ -42,4 +45,8 @@ end
 def get_env_var_rb(name)
   # Get an environment variable in all caps that is prefixed with the name of the project
   return ENV[PROJECT_NAME.upcase + "_" + name.upcase]
+end
+
+def truncate(string, max)
+  string.length > max ? "#{string[0...max]}" : string
 end


### PR DESCRIPTION
Substitutes underscores in guest's hostname for "95" which is the underscore's ascii code. Truncates the non-hash part of the hostname to make the total length less than 64 chars.

**(issue reference)**
Fixes #299, fixes #212

**Does this deserve / include a changlog entry?**
Yes. Included.
